### PR TITLE
.NET Core tests passed on macOS with link to openssl.

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -7,5 +7,6 @@
   <package id="OpenCover" version="4.5.3723" />
   <package id="psake" version="4.4.1" />
   <package id="xunit.runner.console" version="2.2.0-beta2-build3300" />
+  <package id="xunit.runner.visualstudio" version="2.2.0-beta2-build1149" />
   <package id="PublishCoverity" version="0.11.0" />
 </packages>

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,14 @@
 language: csharp
 sudo: required
 dist: trusty
-mono: latest
+
+matrix:
+  include:
+    - dotnet: 1.0.0-preview2-003121
+      mono: none
+      env: DOTNETCORE=1
+    - mono: latest
+      env: IS_MONO=true
     
 os:  
   - linux
@@ -37,10 +44,6 @@ before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
   - export PATH="$DOTNET_INSTALL_DIR:$PATH"  
-  
-  
-install:
-  - travis_retry curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 
 #cache: 
 # - apt
@@ -49,13 +52,13 @@ install:
 
 # Run the build script
 script:
-  - chmod +x .nuget/NuGet.exe
-  - travis_retry nuget install .nuget/packages.config -OutputDirectory packages
-  - travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing
-  - travis_retry dotnet restore --disable-parallel
-  - dotnet test tests/Hangfire.Core.Tests -verbose
-  - xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln
-  - mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll
+  - if test "IS_MONO" == "true"; then chmod +x .nuget/NuGet.exe; fi
+  - if test "IS_MONO" == "true"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
+  - if test "IS_MONO" == "true"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
+  - if test "IS_MONO" == "true"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
+  - if test "IS_MONO" == "true"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
+  - if test "DOTNETCORE" == "1"; then travis_retry dotnet restore --disable-parallel; fi
+  - if test "DOTNETCORE" == "1"; then dotnet test tests/Hangfire.Core.Tests -verbose; fi
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,6 @@ matrix:
       os: osx
       env: NET_PLATFORM=mono
 
-env:  
-  global:
-    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
-
 # Only watch the master branch.
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ branches:
     - master
     - dev
 
+# Make sure build dependencies are installed.
+before_install:  
+  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+
 # Run the build script
 script:
   - if test "$NET_PLATFORM" == "mono"; 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,18 @@ matrix:
   include:
     - dotnet: 1.0.0-preview2-003121
       mono: none
+      os: linux
+      env: DOTNETCORE=1
+    - dotnet: 1.0.0-preview2-003121
+      mono: none
+      os: osx
       env: DOTNETCORE=1
     - mono: latest
+      os: linux
       env: IS_MONO=true
-    
-os:  
-  - linux
-  - osx
+    - mono: latest
+      os: osx
+      env: IS_MONO=true
 
 env:  
   global:
@@ -52,13 +57,13 @@ before_install:
 
 # Run the build script
 script:
-  - if test "IS_MONO" == "true"; then chmod +x .nuget/NuGet.exe; fi
-  - if test "IS_MONO" == "true"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
-  - if test "IS_MONO" == "true"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
-  - if test "IS_MONO" == "true"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
-  - if test "IS_MONO" == "true"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
-  - if test "DOTNETCORE" == "1"; then travis_retry dotnet restore --disable-parallel; fi
-  - if test "DOTNETCORE" == "1"; then dotnet test tests/Hangfire.Core.Tests -verbose; fi
+  - if test "$IS_MONO" == "true"; then chmod +x .nuget/NuGet.exe; fi
+  - if test "$IS_MONO" == "true"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
+  - if test "$IS_MONO" == "true"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
+  - if test "$IS_MONO" == "true"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
+  - if test "$IS_MONO" == "true"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
+  - if test "$DOTNETCORE" == "1"; then travis_retry dotnet restore --disable-parallel; fi
+  - if test "$DOTNETCORE" == "1"; then dotnet test tests/Hangfire.Core.Tests -verbose; fi
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    - CLI_VERSION=1.0.0-preview2-003121
   
 addons:  
   apt:
@@ -50,20 +49,21 @@ before_install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
   - export PATH="$DOTNET_INSTALL_DIR:$PATH"  
 
-#cache: 
-# - apt
-# - directories:
-#   - packages
-
 # Run the build script
 script:
-  - if test "$NET_PLATFORM" == "mono"; then chmod +x .nuget/NuGet.exe; fi
-  - if test "$NET_PLATFORM" == "mono"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
-  - if test "$NET_PLATFORM" == "mono"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
-  - if test "$NET_PLATFORM" == "mono"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
-  - if test "$NET_PLATFORM" == "mono"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
-  - if test "$NET_PLATFORM" == "netcore"; then travis_retry dotnet restore --disable-parallel; fi
-  - if test "$NET_PLATFORM" == "netcore"; then dotnet test tests/Hangfire.Core.Tests -verbose; fi
+  - if test "$NET_PLATFORM" == "mono"; 
+    then 
+        chmod +x .nuget/NuGet.exe;
+        travis_retry nuget install .nuget/packages.config -OutputDirectory packages;
+        travis_retry nuget restore Hangfire.Mono.sln;
+        xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln;
+        mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll -verbose;
+    fi
+  - if test "$NET_PLATFORM" == "netcore"; 
+    then 
+        travis_retry dotnet restore --disable-parallel; 
+        dotnet test tests/Hangfire.Core.Tests -verbose;
+    fi
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
   - travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing
   - travis_retry dotnet restore --disable-parallel
   - dotnet test tests/Hangfire.Core.Tests -verbose
-  - sudo xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln
+  - xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln
   - mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,17 @@ matrix:
     - dotnet: 1.0.0-preview2-003121
       mono: none
       os: linux
-      env: DOTNETCORE=1
+      env: NET_PLATFORM=netcore
     - dotnet: 1.0.0-preview2-003121
       mono: none
       os: osx
-      env: DOTNETCORE=1
+      env: NET_PLATFORM=netcore
     - mono: latest
       os: linux
+      env: NET_PLATFORM=mono
     - mono: latest
       os: osx
+      env: NET_PLATFORM=mono
 
 env:  
   global:
@@ -55,13 +57,13 @@ before_install:
 
 # Run the build script
 script:
-  - if test mono == "latest"; then chmod +x .nuget/NuGet.exe; fi
-  - if test mono == "latest"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
-  - if test mono == "latest"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
-  - if test mono == "latest"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
-  - if test mono == "latest"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
-  - if test "$DOTNETCORE" == "1"; then travis_retry dotnet restore --disable-parallel; fi
-  - if test "$DOTNETCORE" == "1"; then dotnet test tests/Hangfire.Core.Tests -verbose; fi
+  - if test "$NET_PLATFORM" == "mono"; then chmod +x .nuget/NuGet.exe; fi
+  - if test "$NET_PLATFORM" == "mono"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
+  - if test "$NET_PLATFORM" == "mono"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
+  - if test "$NET_PLATFORM" == "mono"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
+  - if test "$NET_PLATFORM" == "mono"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
+  - if test "$NET_PLATFORM" == "netcore"; then travis_retry dotnet restore --disable-parallel; fi
+  - if test "$NET_PLATFORM" == "netcore"; then dotnet test tests/Hangfire.Core.Tests -verbose; fi
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 # Travis-CI Build for Hangfire
 # see travis-ci.org for details
 
-#language: csharp
-language: cpp
+language: csharp
 sudo: required
 dist: trusty
-
+mono: latest
+    
 os:  
   - linux
   - osx
@@ -38,6 +38,7 @@ before_install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
   - export PATH="$DOTNET_INSTALL_DIR:$PATH"  
   
+  
 install:
   - travis_retry curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 
@@ -48,14 +49,13 @@ install:
 
 # Run the build script
 script:
+  - chmod +x .nuget/NuGet.exe
+  - travis_retry nuget install .nuget/packages.config -OutputDirectory packages
+  - travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing
   - travis_retry dotnet restore --disable-parallel
   - dotnet test tests/Hangfire.Core.Tests -verbose
- 
-# Tests on Mono disabled – waiting for https://github.com/NuGet/Home/issues/3085
-# - travis_retry mono .nuget/NuGet.exe install .nuget/packages.config -OutputDirectory packages
-# - travis_retry mono .nuget/NuGet.exe install .
-# - xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln
-# - mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll
+  - sudo xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln
+  - mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ matrix:
       env: DOTNETCORE=1
     - mono: latest
       os: linux
-      env: IS_MONO=true
     - mono: latest
       os: osx
-      env: IS_MONO=true
 
 env:  
   global:
@@ -57,11 +55,11 @@ before_install:
 
 # Run the build script
 script:
-  - if test "$IS_MONO" == "true"; then chmod +x .nuget/NuGet.exe; fi
-  - if test "$IS_MONO" == "true"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
-  - if test "$IS_MONO" == "true"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
-  - if test "$IS_MONO" == "true"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
-  - if test "$IS_MONO" == "true"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
+  - if test mono == "latest"; then chmod +x .nuget/NuGet.exe; fi
+  - if test mono == "latest"; then travis_retry nuget install .nuget/packages.config -OutputDirectory packages; fi
+  - if test mono == "latest"; then travis_retry nuget restore Hangfire.Mono.sln -verbosity detailed -disableparallelprocessing; fi
+  - if test mono == "latest"; then xbuild /p:Configuration=Release /verbosity:minimal Hangfire.Mono.sln; fi
+  - if test mono == "latest"; then mono ./packages/xunit.runner.console.2.2.0-beta2-build3300/tools/xunit.console.exe ./tests/Hangfire.Core.Tests/bin/Release/Hangfire.Core.Tests.dll; fi
   - if test "$DOTNETCORE" == "1"; then travis_retry dotnet restore --disable-parallel; fi
   - if test "$DOTNETCORE" == "1"; then dotnet test tests/Hangfire.Core.Tests -verbose; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,28 +26,12 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
-  
-addons:  
-  apt:
-    packages:
-    - gettext
-    - libcurl4-openssl-dev
-    - libicu-dev
-    - libssl-dev
-    - libunwind8
-    - zlib1g
 
 # Only watch the master branch.
 branches:
   only:
     - master
     - dev
-
-# Make sure build dependencies are installed.
-before_install:  
-  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"  
 
 # Run the build script
 script:

--- a/tests/Hangfire.Core.Tests/BackgroundJobFacts.cs
+++ b/tests/Hangfire.Core.Tests/BackgroundJobFacts.cs
@@ -16,6 +16,12 @@ namespace Hangfire.Core.Tests
         {
             _client = new Mock<IBackgroundJobClient>();
         }
+
+        [Fact]
+        public void FailedTest()
+        {
+            Assert.True(false);
+        }
         
         [Fact, GlobalLock(Reason = "Access BackgroundJob.ClientFactory member")]
         public void Enqueue_CreatesAJobInEnqueuedState()

--- a/tests/Hangfire.Core.Tests/BackgroundJobFacts.cs
+++ b/tests/Hangfire.Core.Tests/BackgroundJobFacts.cs
@@ -16,12 +16,6 @@ namespace Hangfire.Core.Tests
         {
             _client = new Mock<IBackgroundJobClient>();
         }
-
-        [Fact]
-        public void FailedTest()
-        {
-            Assert.True(false);
-        }
         
         [Fact, GlobalLock(Reason = "Access BackgroundJob.ClientFactory member")]
         public void Enqueue_CreatesAJobInEnqueuedState()


### PR DESCRIPTION
This PR was created to check that you can use Travis CI for testing your .NET Core app on macOS with explicit linking to openSSL lib.

Related PR in travis-build repo: [#918](https://github.com/travis-ci/travis-build/pull/918)